### PR TITLE
grm, don't use cftime with dates

### DIFF
--- a/basin_setup/grm.py
+++ b/basin_setup/grm.py
@@ -446,7 +446,12 @@ class GRM(object):
         """
 
         times = self.ds.variables['time']
-        ncdates = nc.num2date(times[:], times.units, calendar=times.calendar)
+        ncdates = nc.num2date(
+            times[:],
+            times.units,
+            calendar=times.calendar,
+            only_use_cftime_datetimes=False
+        )
         ncdates = np.array([pd.to_datetime(dt).date() for dt in ncdates])
 
         # Is the incoming date already in the file?

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ utm==0.4.2
 coloredlogs==10.0
 spatialnc>=0.3.0,<0.4.0
 inicheck>=0.9,<0.10.0
-netcdf4==1.4.1
+netcdf4>=1.4.1
 cftime<1.1.0
 xarray>=0.16.2
 rioxarray>=0.3.1


### PR DESCRIPTION
`cftime` can cause a fair bit of issues with dates and has been documented with SMRF. The simple solution is to not use `cftime` objects when converting dates.

```python
ncdates = nc.num2date(
            times[:],
            times.units,
            calendar=times.calendar,
            only_use_cftime_datetimes=False
        )
```